### PR TITLE
Fix terminal corruption around mpv video playback

### DIFF
--- a/goonget/display_handler.py
+++ b/goonget/display_handler.py
@@ -7,16 +7,23 @@ import sys
 import select
 import shutil
 import subprocess
+import atexit
 from .settings_handler import get_current_size, get_slideshow_timer, get_source, get_show_source_links
 
 SUPPORTED_IMAGE_FORMATS = {"jpg", "jpeg", "png", "webp"}
 SUPPORTED_GIF_FORMATS = {"gif"}
-SUPPORTED_VIDEO_FORMATS = {"mp4", "webm", "mkv"}  
+SUPPORTED_VIDEO_FORMATS = {"mp4", "webm", "mkv"}
 
-def display_result(urls):
+# Exit code mpv returns when the user presses ENTER during slideshow playback
+# (bound via a temp input.conf below). Distinct from q / natural end, which are 0.
+_SLIDESHOW_STOP_CODE = 47
+
+def display_result(urls, slideshow: bool = False) -> bool:
+    """Display a single result. Returns True only if the user asked to stop the
+    slideshow (ENTER pressed during a video); False otherwise."""
     if not urls:
         print("No URLs provided.")
-        return
+        return False
 
     file_url = urls["file_url"]
     source_url = urls["source_url"]
@@ -28,9 +35,10 @@ def display_result(urls):
     elif ext in SUPPORTED_GIF_FORMATS:
         _handle_gif(file_url, source_url, ext, show_src_links)
     elif ext in SUPPORTED_VIDEO_FORMATS:
-        _handle_video(file_url, source_url, ext, show_src_links)
+        return _handle_video(file_url, source_url, ext, show_src_links, slideshow)
     else:
         print(f"Unsupported file type: .{ext}")
+    return False
 
 def display_slideshow(urls: list[str]):
     timer = get_slideshow_timer()
@@ -38,17 +46,27 @@ def display_slideshow(urls: list[str]):
         print("No non-GIF images found.")
         return
 
-    while True:
-        random.shuffle(urls)
-        print("Slideshow mode! Stop by pressing Enter!")
-        time.sleep(2)
-        for url in urls:
-            _clear_screen()
-            display_result(url)
-            # Wait for timer OR keypress 
-            if _wait_or_keypress(timer): 
-                print("Slideshow stopped.") 
-                return
+    print("Slideshow mode! Stop by pressing Enter!")
+    time.sleep(2)
+    try:
+        while True:
+            random.shuffle(urls)
+            for url in urls:
+                _clear_screen()
+                is_video = _get_extension(url["file_url"]) in SUPPORTED_VIDEO_FORMATS
+                # During a video, mpv owns stdin; ENTER is bound to quit-with-code
+                # so display_result can report a stop request.
+                if display_result(url, slideshow=True):
+                    return
+                # For images/gifs, wait out the timer (or stop on a keypress).
+                # Videos already gave the user their viewing time + stop chance.
+                if not is_video and _wait_or_keypress(timer):
+                    return
+    except KeyboardInterrupt:
+        pass
+    finally:
+        _reset_terminal()
+        print("Slideshow stopped.")
 
 
 def _get_extension(url: str) -> str:
@@ -124,21 +142,37 @@ def _handle_gif(file_url: str, source_url: str, ext: str, show_src_links: bool):
 
     _cleanup(path)
 
-def _handle_video(file_url: str, source_url: str, ext: str, show_src_links: bool):
+def _handle_video(file_url: str, source_url: str, ext: str, show_src_links: bool,
+                  slideshow: bool = False) -> bool:
     path = _download_to_temp(file_url, ext)
     if not path:
-        return
+        return False
 
+    stop_requested = False
     try:
         if shutil.which("mpv"):
-            subprocess.run(["mpv", "--profile=sw-fast", "--vo=kitty", "--really-quiet", path], stderr=subprocess.DEVNULL)
+            cmd = ["mpv", "--profile=sw-fast", "--vo=kitty", "--really-quiet"]
+            if slideshow:
+                # Bind ENTER -> quit with our sentinel code so pressing ENTER
+                # during playback stops the whole slideshow.
+                cmd.append("--input-conf=" + _slideshow_input_conf())
+            cmd.append(path)
+            result = subprocess.run(cmd, stderr=subprocess.DEVNULL)
+            if slideshow and result.returncode == _SLIDESHOW_STOP_CODE:
+                stop_requested = True
         else:
             if shutil.which("xdg-open"):
                 subprocess.run(["xdg-open", path], stderr=subprocess.DEVNULL)
             else:
                 print("No suitable video player found. Install mpv or set a default via xdg-mime.")
     finally:
+        # mpv enables mouse reporting / alt-screen / hides the cursor and draws
+        # kitty-graphics frames. If it exited cleanly it restores all of that, but
+        # an interrupted exit (Ctrl+C mashed, crash) leaks those modes into the
+        # shell. Reset defensively so the terminal is always usable afterwards.
+        _reset_terminal()
         _cleanup(path)
+    return stop_requested
 
 
 def _cleanup(path: str):
@@ -148,7 +182,35 @@ def _cleanup(path: str):
         pass
 
 def _clear_screen():
-    print("\033[2J\033[H", flush=True)
+    # Use write() (not print, which appends a newline that pushes the next image
+    # down a row). \033[3J clears scrollback and the kitty graphics-delete removes
+    # any leftover frames so the next chafa image is not shifted/overlaid.
+    sys.stdout.write("\033[3J\033[2J\033[H\033_Ga=d,d=A\033\\")
+    sys.stdout.flush()
+
+def _reset_terminal():
+    sys.stdout.write(
+        "\033[?1000l\033[?1002l\033[?1003l\033[?1006l\033[?1015l"  # disable mouse reporting
+        "\033[?1049l"          # leave the alternate screen, if still in it
+        "\033[?25h"            # show the cursor
+        "\033_Ga=d,d=A\033\\"  # delete all kitty graphics images
+    )
+    sys.stdout.flush()
+
+_mpv_input_conf = None
+
+def _slideshow_input_conf() -> str:
+    """Path to a small mpv input.conf binding ENTER to quit with our sentinel
+    exit code. Created once and reused for the session."""
+    global _mpv_input_conf
+    if _mpv_input_conf and os.path.exists(_mpv_input_conf):
+        return _mpv_input_conf
+    f = tempfile.NamedTemporaryFile("w", suffix=".conf", delete=False)
+    f.write(f"ENTER quit {_SLIDESHOW_STOP_CODE}\n")
+    f.close()
+    _mpv_input_conf = f.name
+    atexit.register(lambda: _cleanup(_mpv_input_conf))
+    return _mpv_input_conf
 
 def _wait_or_keypress(seconds: float) -> bool:
     r, _, _ = select.select([sys.stdin], [], [], seconds)

--- a/goonget/main.py
+++ b/goonget/main.py
@@ -3,7 +3,7 @@ import sys
 import random
 import curses
 from .api_calls import fetch_posts
-from .display_handler import display_result, display_slideshow
+from .display_handler import display_result, display_slideshow, _reset_terminal
 from .help import print_help
 from .settings_ncurses import open_settings
 from .settings_handler import (
@@ -14,6 +14,16 @@ from .settings_handler import (
 
 
 def main():
+    try:
+        _run()
+    except KeyboardInterrupt:
+        # mpv's finally already restores the terminal; reset again in case the
+        # interrupt landed elsewhere, and exit quietly instead of dumping a traceback.
+        _reset_terminal()
+        print()
+
+
+def _run():
     args = sys.argv[1:]
 
     # open settings page


### PR DESCRIPTION
After the mpv video feature landed, three terminal-state bugs show up around video playback. All three share a root cause: the app delegated 100% of terminal-state management to mpv/chafa and did nothing defensive, so anything that cut mpv's shutdown short (or any kitty-graphics leftover) leaked into the shell.

## Bugs & root causes

**1. Mouse-reporting garbage in the shell after Ctrl+C**
mpv always enables mouse reporting (`\033[?1003h`) + the alternate screen and only restores them on a *full* shutdown. An interrupted exit (mashed Ctrl+C, crash, SIGKILL) leaks those modes, so afterwards every mouse move spews escape sequences at the prompt. Verified via a pty capture: mpv emits `[?1003l` on a clean/SIGINT exit, but not when its cleanup is cut short.

**2. The next image is shifted / overlaps after a video**
Both mpv and chafa draw via the **kitty graphics protocol**, but `_clear_screen()` only did `\033[2J\033[H`, which clears text but does **not** delete kitty images — leftover frames persisted under the next chafa render. Also `print(...)` appended a stray newline that pushed each render down one row.

**3. ENTER doesn't stop a slideshow while a video plays**
mpv owns stdin during playback and has no ENTER binding, so the slideshow's keypress check only ran *after* mpv exited.

## Fixes
- `_reset_terminal()` called in `_handle_video`'s `finally`: defensively disables mouse modes, leaves the alt-screen, shows the cursor and deletes kitty graphics — regardless of how mpv exited.
- `_clear_screen()` now uses `write()` (no stray newline), clears scrollback and deletes kitty graphics, so the next image isn't shifted/overlaid.
- In slideshow mode, ENTER is bound to `quit 47` via a small temp `input.conf`; `_handle_video` reports a stop request when mpv exits with that code (distinct from `q`/natural end = 0), propagated through `display_result` to `display_slideshow`. The post-video timer is skipped (the video already gave viewing time + a stop chance).
- `KeyboardInterrupt` is handled in `main()` and `display_slideshow()` so Ctrl+C exits quietly with the terminal restored instead of dumping a traceback.

## Verification
Tested against mpv 0.41 + chafa 1.18 in kitty using a pty harness on a synthetic `testsrc` clip:
- ENTER during a slideshow video → stop (exit 47); `q` / natural end → continue (exit 0).
- Simulating mpv being SIGKILLed after it enabled mouse (so it can't clean up): the `finally` reset still leaves mouse reporting **off**.
- `_clear_screen()` emits no trailing newline and includes the kitty graphics-delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)